### PR TITLE
Revert "chore(deps-dev): bump replace-in-file from 6.3.5 to 7.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "minimist": "^1.2.8",
         "prettier": "2.8.8",
         "release-it": "^15.10.1",
-        "replace-in-file": "^7.0.1",
+        "replace-in-file": "^6.3.5",
         "typescript": "^5.0.4",
         "zotero-types": "^1.0.13"
     },


### PR DESCRIPTION
Reverts northword/zotero-format-metadata#32
This version of the package has a bug that makes packaging on Windows failed.