### PR TITLE
fix: use `addTag` instead of `setTags` to set `linter/error` tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix issue that Lint error would clear all tags. closes: [#221](https://github.com/northword/zotero-format-metadata/issues/221)
+
 ## [1.18.4] - 2024-08-31
 
 ### Fixed

--- a/src/modules/rules-runner.ts
+++ b/src/modules/rules-runner.ts
@@ -47,13 +47,13 @@ export class LintRunner {
                 item = await rule.apply(item);
             } catch (err) {
                 logError(err, item);
-                item.addTag("linter/error");
+                item.addTag("linter/error", 1);
                 await item.saveTx();
                 throw err;
             }
         }
         ztoolkit.log("[Runner] Item returned: ", item);
-        if (item.getTags().includes({ tag: "linter/error", type: 1 })) {
+        if (item.hasTag("linter/error")) {
             item.removeTag("linter/error");
         }
         await item.saveTx();

--- a/src/modules/rules-runner.ts
+++ b/src/modules/rules-runner.ts
@@ -47,7 +47,7 @@ export class LintRunner {
                 item = await rule.apply(item);
             } catch (err) {
                 logError(err, item);
-                item.setTags(["linter/error"]);
+                item.addTag("linter/error");
                 await item.saveTx();
                 throw err;
             }


### PR DESCRIPTION
…ter/error” tag.

Use addTag instead of setTags to set the “linter/error” tag.

#221 