### PR TITLE
fix: language settings parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix language settings parsing, by @thebluepotato in [#229](https://github.com/northword/zotero-format-metadata/pull/229).
+
 ## [1.18.6] - 2024-09-15
 
 ### Fixed

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -54,7 +54,7 @@ language-fill-option-only-cmn =
 language-fill-option-only-eng = 
     .label = English (en)
 language-fill-option-only-other = and:
-language-fill-option-only-other-desc = Here you need to enter the ISO 639-1 language code, separated by a semi-colon comma.
+language-fill-option-only-other-desc = Enter a comma-separated list of additional ISO 639-1 language codes.
 language-fill-option-only-other-doc = ISO 639-1 code
     .href = https://github.com/northword/zotero-format-metadata#readme
 

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -457,7 +457,7 @@ export function getTextLanguage(text: string) {
         if (getPref("lang.only.eng")) options.only.push("en");
         const otherLang = getPref("lang.only.other") as string;
         if (otherLang !== "" && otherLang !== undefined)
-            options.only.push.apply(otherLang.replace(/ /g, "").split(","));
+            options.only.push(...otherLang.replace(/ /g, "").split(","));
     }
     ztoolkit.log("[lang] Selected ISO 639-1 code is: ", options.only);
 

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -456,8 +456,7 @@ export function getTextLanguage(text: string) {
         if (getPref("lang.only.cmn")) options.only.push("zh");
         if (getPref("lang.only.eng")) options.only.push("en");
         const otherLang = getPref("lang.only.other") as string;
-        if (otherLang !== "" && otherLang !== undefined)
-            options.only.push(...otherLang.replace(/ /g, "").split(","));
+        if (otherLang !== "" && otherLang !== undefined) options.only.push(...otherLang.replace(/ /g, "").split(","));
     }
     ztoolkit.log("[lang] Selected ISO 639-1 code is: ", options.only);
 


### PR DESCRIPTION
Fixes the settings for checking "additional" languages. `push.apply` should have two arguments, namely the two arrays to be pushed together. Much simpler and clearer to use regular push with `...`. Now the additional languages are actually added. Also fixes the description in the settings to clearly state that a **comma**-separated list is expected.