### PR TITLE
fix: broken supscript shortcut on macos, fixes #215

### DIFF
--- a/src/modules/shortcuts.ts
+++ b/src/modules/shortcuts.ts
@@ -4,7 +4,8 @@ export function registerShortcuts() {
       if (data.keyboard.equals("accel,=")) {
         addon.hooks.onShortcuts("subscript");
       }
-      if (data.keyboard.equals("accel,+") || data.keyboard.equals("accel,shift,+")) {
+      // `accel,shift,=` is for compatibility with macOS
+      if (data.keyboard.equals("accel,+") || data.keyboard.equals("accel,shift,+") || data.keyboard.equals("accel,shift,=")) {
         addon.hooks.onShortcuts("supscript");
       }
       if (data.keyboard.equals("accel,B")) {


### PR DESCRIPTION
fixes #215

Tested on macOS 15
<img width="876" height="49" alt="2025-09-17" src="https://github.com/user-attachments/assets/834df7f1-0256-4ee8-91e3-9d647aa5411c" />
