### PR TITLE
fix: keep iScience-like and npj series publication title

### DIFF
--- a/src/modules/rules/correct-publication-title.ts
+++ b/src/modules/rules/correct-publication-title.ts
@@ -15,6 +15,9 @@ export const CorrectPublicationTitle = defineRule({
     if (publicationTitleDisambiguation) {
       newPublicationTitle = publicationTitleDisambiguation;
     }
+    else if (keepOriginPublicationTitle(publicationTitle)) {
+      newPublicationTitle = publicationTitle;
+    }
     else {
       newPublicationTitle = capitalizePublicationTitle(publicationTitle, isFullUpperCase(publicationTitle));
     }
@@ -352,4 +355,12 @@ async function getPublicationTitleDisambiguation(publicationTitle: string) {
     }
   }
   return false;
+}
+
+// For iScience-link publication title, keep origin
+function keepOriginPublicationTitle(publicationTitle: string): boolean {
+  return publicationTitle.split(" ").length === 1
+    && publicationTitle.length > 1
+    && publicationTitle.charAt(0) === publicationTitle.charAt(0).toLowerCase()
+    && publicationTitle.charAt(1) === publicationTitle.charAt(1).toUpperCase();
 }

--- a/src/modules/rules/correct-publication-title.ts
+++ b/src/modules/rules/correct-publication-title.ts
@@ -316,6 +316,7 @@ const skipWordsForPublicationTitle = [
   "SA",
   "ZDM",
   "ZKG",
+  "npj",
 ];
 
 // 期刊名应词首大写


### PR DESCRIPTION
- iScience, eScience, eTransportation, eLife, eLight, mLife, mSphere, mSystems, eCancerMedicalScience等期刊
- npj系列期刊且不在 https://github.com/northword/zotero-format-metadata/blob/main/data/journal-abbr/journal-abbr.json 中的，例如npj Aging等，See https://www.nature.com/nature-portfolio/about/npj-series