### PR TITLE
chore: add correct-creators-pinyin checkbox

### DIFF
--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -141,6 +141,12 @@
         preference="rule.correct-creators-case"
         native="true"
       />
+      <!-- 修改作者中文拼音是否拆分 -->
+      <checkbox
+        data-l10n-id="rule-correct-creators-pinyin"
+        preference="rule.correct-creators-pinyin"
+        native="true"
+      />
     </groupbox>
 
     <!-- 字段：语言 -->

--- a/addon/locale/en-US/rules.ftl
+++ b/addon/locale/en-US/rules.ftl
@@ -78,7 +78,7 @@ rule-correct-creators-case-menu-item = Fix case of creators
 
 ## correct-creators-pinyin
 rule-correct-creators-pinyin =
-  .label = Chinese creators’ Pinyin should be hyphenated
+  .label = Chinese creators' Pinyin should be splitted (i.e. Zhang Sanfeng → Zhang San Feng)
 rule-correct-creators-pinyin-menu-item = Split creator Pinyin
 
 

--- a/addon/locale/zh-CN/rules.ftl
+++ b/addon/locale/zh-CN/rules.ftl
@@ -76,7 +76,7 @@ rule-correct-creators-case-menu-item = 修正作者的大小写
 
 ## correct-creators-pinyin
 rule-correct-creators-pinyin =
-  .label = 作者中的中文拼音应以短划线分隔
+  .label = 作者中的中文拼音应被拆分（即Zhang Sanfeng → Zhang San Feng）
 rule-correct-creators-pinyin-menu-item = 拆分作者拼音
 
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -45,7 +45,7 @@ pref("rule.correct-title-sentence-case", true);
 pref("rule.correct-title-sentence-case.custom-term-path", "");
 pref("rule.correct-shortTitle-sentence-case", true);
 pref("rule.correct-creators-case", true);
-pref("rule.correct-creators-pinyin", true);
+pref("rule.correct-creators-pinyin", false);
 pref("rule.correct-date-format", true);
 pref("rule.correct-publication-title", true);
 pref("rule.correct-pages-connector", true);


### PR DESCRIPTION
- v2.0.0 refactor后（v1.26.0 standard流程没有这一项，仅context menu有），https://github.com/northword/zotero-format-metadata/blob/main/addon/prefs.js#L48 将 `rule.correct-creators-pinyin` 设置为true，使得standard流程也会拆分拼音，且无法uncheck，因此增加checkbox。
- 另：改为默认不启用此功能，避免在用户不了解此功能的情况下，creators被拆分