### PR TITLE
fix(rich-text): update context pane header reference

### DIFF
--- a/src/modules/rich-text.ts
+++ b/src/modules/rich-text.ts
@@ -231,7 +231,7 @@ export class RichTextToolBar {
 
   private get contextPaneHeader(): HTMLElement | null {
     // @ts-expect-error ZoteroContextPane has context
-    return ztoolkit.getGlobal("ZoteroContextPane").context;
+    return ztoolkit.getGlobal("ZoteroContextPane").context._itemPaneDeck.firstChild._header;
   }
 
   /**


### PR DESCRIPTION
The context pane header element reference has been updated to target the correct DOM node. This change ensures proper access to the header element within the item pane deck structure.