### PR TITLE
fix(abbr, publicationTitle-alias): Matéria (Rio de Janeiro)

### DIFF
--- a/data/journal-abbr/override.csv
+++ b/data/journal-abbr/override.csv
@@ -12,7 +12,7 @@
 ## UBC, 241104
 "Annals of Mathematical Sciences and Applications","Ann. Math. Sci. Appl."
 
-## Angewandte Chemie, 250106, use officeal abbr and name
+## Angewandte Chemie, 250106, use official abbr and name
 "Angewandte Chemie International Edition","Angew. Chem. Int. Ed."
 
 ## Renew. Sustain. Energy Rev., 250306
@@ -26,3 +26,6 @@
 
 ## 251023, ubc, ubc has two alias for Nano-Micro Letters, we use the official one
 "Nano-Micro Letters","Nano-Micro Lett."
+
+## 251023, Matéria (Rio de Janeiro), use official name and abbr, https://www.scielo.br/journal/rmat/about/
+"Matéria (Rio de Janeiro)","Matéria (Rio J.)"


### PR DESCRIPTION
Matéria (Rio de Janeiro) --> Matéria (Rio J.) refs: https://www.scielo.br/journal/rmat/about/
This journal is absent in [abbrv.jabref.org](https://github.com/JabRef/abbrv.jabref.org/tree/176c06c4727fa1005117ead24e8d5b9051e4f3ab).