### PR TITLE
fix(title): normalize space before colon in correct-title-punctuation

### DIFF
--- a/src/modules/rules/correct-punctuation.test.ts
+++ b/src/modules/rules/correct-punctuation.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { convertQuotesToCurly, normalizeHyphens, normalizeInterpuncts } from "./correct-punctuation";
+import { convertQuotesToCurly, normalizeHyphens, normalizeInterpuncts, normalizeSpacesBeforeColon } from "./correct-punctuation";
+
+describe("normalizeSpacesBeforeColon", () => {
+  it("removes single space before colon", () => {
+    const input = "Moving : Living in Place";
+    const out = normalizeSpacesBeforeColon(input);
+    expect(out).toBe("Moving: Living in Place");
+  });
+
+  it("removes multiple spaces before colon", () => {
+    const input = "Ecology  : A New Approach";
+    const out = normalizeSpacesBeforeColon(input);
+    expect(out).toBe("Ecology: A New Approach");
+  });
+
+  it("leaves colon without preceding space unchanged", () => {
+    const input = "Moving: Living in Place";
+    const out = normalizeSpacesBeforeColon(input);
+    expect(out).toBe("Moving: Living in Place");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeSpacesBeforeColon("")).toBe("");
+  });
+
+  it("handles string with no colons", () => {
+    const input = "Just a regular title";
+    const out = normalizeSpacesBeforeColon(input);
+    expect(out).toBe("Just a regular title");
+  });
+});
 
 describe("normalizeHyphens", () => {
   it("normalizes various hyphen-like characters to hyphen-minus", () => {

--- a/src/modules/rules/correct-punctuation.ts
+++ b/src/modules/rules/correct-punctuation.ts
@@ -28,6 +28,13 @@ export function normalizeInterpuncts(text: string): string {
   return text.replace(interpunctPattern, "\u00B7");
 }
 
+/**
+ * Remove extra spaces before a colon (e.g. "Moving : Living in Place" → "Moving: Living in Place")
+ */
+export function normalizeSpacesBeforeColon(text: string): string {
+  return text.replace(/ +:/g, ":");
+}
+
 /** ================================================================================= */
 
 /**
@@ -49,8 +56,9 @@ export const CorrectTitlePunctuation = defineRule({
       return;
 
     let newTitle = normalizeHyphens(title);
+    newTitle = normalizeSpacesBeforeColon(newTitle);
     if (getPref("rule.correct-title-punctuation.quotes")) {
-      newTitle = convertQuotesToCurly(title);
+      newTitle = convertQuotesToCurly(newTitle);
       debug("Converted quotes to curly");
     }
 


### PR DESCRIPTION
## Problem

Titles imported from some databases (e.g. library catalogs, MARC records) often contain a space before a colon in subtitles:

  Moving : Living in Place

This is technically valid ISBD punctuation but is incorrect for standard bibliographic metadata. Zotero's sentence-case rule already capitalizes the word after a colon, but no existing rule removes the leading space.

The custom terms CSV cannot fix this because it operates word-by-word during sentence-case conversion, not as a raw string replacement.

## Solution

Add a single substitution to `correct-punctuation.ts` to strip one or more spaces immediately before a colon:

  / +:/ → /:/

## Examples

| Before | After |
|---|---|
| `Moving : Living in Place` | `Moving: Living in Place` |
| `Ecology  : A New Approach` | `Ecology: A New Approach` |

## Notes

- Only affects space *before* the colon, not after (post-colon spacing is already handled by the sentence-case rule's capitalization logic)
- Follows the same pattern as other spacing normalizations in this rule
- Adds 5 unit tests for the new function
- All 101 unit tests pass