### PR TITLE
chore: add a hidden pref to allow changing the lintOnAdded delay time

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -7,6 +7,7 @@ pref("lint.onAdded", true);
 pref("lint.onGroup", false);
 pref("lint.notify", true);
 pref("lint.numConcurrent", 1);
+pref("lint.delayOnAdded", 500);
 
 // --------------------
 // Richtext settings
@@ -84,4 +85,3 @@ pref("semanticScholarToken", "");
 // Other settings
 // --------------------
 pref("cleanExtra", false);
-pref("lint.delayOnAdded", 500);

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -84,3 +84,4 @@ pref("semanticScholarToken", "");
 // Other settings
 // --------------------
 pref("cleanExtra", false);
+pref("lint.delayOnAdded", 500);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -70,8 +70,7 @@ async function onNotify(
 
   // Wait a short time to allow other plugins' changes to be saved
   // Use hidden pref `lint.delayOnAdded` but enforce a minimum of 500ms
-  const rawDelay = getPref("lint.delayOnAdded") as number;
-  const delay = Math.max(500, rawDelay);
+  const delay = Math.max(500, getPref("lint.delayOnAdded"));
   await Zotero.Promise.delay(delay);
 
   const items = Zotero.Items.get(ids as number[]).filter(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -68,8 +68,11 @@ async function onNotify(
   if (extraData.skipAutoSync)
     return;
 
-  // Wait 500ms to wait other plugins changes saved
-  await Zotero.Promise.delay(500);
+  // Wait a short time to allow other plugins' changes to be saved
+  // Use hidden pref `lint.delayOnAdded` but enforce a minimum of 500ms
+  const rawDelay = getPref("lint.delayOnAdded") as number;
+  const delay = Math.max(500, rawDelay);
+  await Zotero.Promise.delay(delay);
 
   const items = Zotero.Items.get(ids as number[]).filter(
     (item) => {

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -12,6 +12,7 @@ declare namespace _ZoteroTypes {
       "lint.onGroup": boolean;
       "lint.notify": boolean;
       "lint.numConcurrent": number;
+      "lint.delayOnAdded": number;
       "richtext.toolBar": boolean;
       "richtext.hotkey": boolean;
       "richtext.preview": boolean;
@@ -71,7 +72,6 @@ declare namespace _ZoteroTypes {
       "rule.tool-update-metadata.option.allow-type-changed": boolean;
       "semanticScholarToken": string;
       "cleanExtra": boolean;
-      "lint.delayOnAdded": number;
     };
   }
 }

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -71,6 +71,7 @@ declare namespace _ZoteroTypes {
       "rule.tool-update-metadata.option.allow-type-changed": boolean;
       "semanticScholarToken": string;
       "cleanExtra": boolean;
+      "lint.delayOnAdded": number;
     };
   }
 }


### PR DESCRIPTION
Currently, due to an excessive number of plugins or computer performance limitations, title case may often fail to be corrected when adding items. A hidden preference has been added to allow users to extend the delay time.