### PR TITLE
fix: match conference names across edition ordinals

### DIFF
--- a/addon/locale/zh-CN/rules.ftl
+++ b/addon/locale/zh-CN/rules.ftl
@@ -253,7 +253,7 @@ rule-no-volume-extra-zeros =
 rule-correct-conference-abbr =
   .label = 会议名的缩写填入 extra.shortConferenceName 字段
 rule-correct-conference-abbr-menu-item =
-  .label = 查找会议缩写
+  .label = 自动填充会议缩写
 rule-correct-conference-abbr-description = 此规则与「{ rule-require-journal-abbr.label }」共享配置 
 
 

--- a/src/modules/rules/require-abbr.ts
+++ b/src/modules/rules/require-abbr.ts
@@ -107,15 +107,26 @@ export const CorrectConferenceAbbr = defineRule<Options>({
     let shortConferenceName: string | undefined;
 
     for (const conferenceName of conferenceNames) {
-      // 从自定义数据集获取
-      if (options.customDataPath !== "") {
-        shortConferenceName = await getAbbrFromCustom(conferenceName, options.customDataPath);
-      }
+      // 先精确匹配，再移除会议届次序数（如 32nd）后匹配
+      const conferenceNameWithoutOrdinal = conferenceName.replace(/\b\d+(?:st|nd|rd|th)\b/gi, "");
+      const conferenceNameVariants = conferenceNameWithoutOrdinal === conferenceName
+        ? [conferenceName]
+        : [conferenceName, conferenceNameWithoutOrdinal];
 
-      // 从本地数据集获取缩写
-      if (!shortConferenceName) {
-        const data = await DataLoader.load("conferencesAbbr");
-        shortConferenceName = await getAbbrLocally(conferenceName, data);
+      for (const conferenceNameVariant of conferenceNameVariants) {
+        // 从自定义数据集获取
+        if (options.customDataPath !== "") {
+          shortConferenceName = await getAbbrFromCustom(conferenceNameVariant, options.customDataPath);
+        }
+
+        // 从本地数据集获取缩写
+        if (!shortConferenceName) {
+          const data = await DataLoader.load("conferencesAbbr");
+          shortConferenceName = await getAbbrLocally(conferenceNameVariant, data);
+        }
+
+        if (shortConferenceName)
+          break;
       }
 
       if (shortConferenceName)


### PR DESCRIPTION
## Summary

- Keep exact conference-name matching as the first choice.
- If no abbreviation is found, retry after removing English edition ordinals such as `31st`, `32nd`, and `33rd`.
- Align the Chinese conference-abbreviation item-menu label with the existing journal-abbreviation action.

## Problem

Conference proceedings often include an edition ordinal in `conferenceName` or `proceedingsTitle`. For example, `Proceedings of the 32nd ACM International Conference on Multimedia` did not match a custom CSV entry for `Proceedings of the ACM International Conference on Multimedia`.

## Scope

This is a focused follow-up to #430. It does not change item-tree data retrieval, journal-abbreviation handling, the custom CSV structure, or existing helper functions.

## Validation

- 102 unit tests passed; 1 test skipped.
- TypeScript check passed.
- ESLint and AutoCorrect checks passed for the changed files.
- Production XPI build passed.
- Manually verified in Zotero with a custom CSV, including existing `Extra` content and a `32nd` conference title.

## Participation

- Implementation and code review were assisted by OpenAI Codex.
- Scope decisions and Zotero behavior were manually tested and verified by Anonymous-26.
