### PR TITLE
feat: preference to suppress the report window after lint

### DIFF
--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -28,6 +28,11 @@
       preference="lint.notify"
       native="true"
     />
+    <checkbox
+      data-l10n-id="show-report-on-lint"
+      preference="lint.showReportDialog"
+      native="true"
+    />
     <!-- lint.numConcurrent -->
     <hbox align="center">
       <label data-l10n-id="lint-numConcurrent" />

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -6,6 +6,8 @@ lint-on-groupItem-added =
     .label = Lint when item added to group
 notify-on-lint = 
     .label = Show progress notification when Lint
+show-report-on-lint = 
+    .label = Show report window after Lint finds issues
 lint-numConcurrent = Number of concurrent: 
 lint-numConcurrent-description = Recommended: 1 ({ restart-needed.short }).
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -6,6 +6,8 @@ lint-on-groupItem-added =
     .label = 添加群组条目时自动执行 Lint
 notify-on-lint = 
     .label = Lint 时显示进度通知
+show-report-on-lint = 
+    .label = Lint 发现问题后显示报告窗口
 lint-numConcurrent = 并行运行的数量：
 lint-numConcurrent-description = 推荐设置为 1 ({ restart-needed.short })。
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -6,6 +6,7 @@ pref("version", "__buildVersion__");
 pref("lint.onAdded", true);
 pref("lint.onGroup", false);
 pref("lint.notify", true);
+pref("lint.showReportDialog", true);
 pref("lint.numConcurrent", 1);
 pref("lint.delayOnAdded", 500);
 

--- a/src/modules/runner.ts
+++ b/src/modules/runner.ts
@@ -290,7 +290,7 @@ export class LintRunner {
     const duration = (Date.now() - this.stats.startTime) / 1000;
     this.ui.showFinished(this.stats.pass, this.stats.error, duration);
 
-    if (this.stats.records.length)
+    if (this.stats.records.length && getPref("lint.showReportDialog"))
       createReporter(this.stats.records);
 
     DataLoader.clearCache();

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -173,6 +173,7 @@ export type FluentMessageId =
   | 'shortcut-subscript'
   | 'shortcut-supscript'
   | 'shortcuts-header'
+  | 'show-report-on-lint'
   | 'small-caps'
   | 'subscript'
   | 'supscript'

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -11,6 +11,7 @@ declare namespace _ZoteroTypes {
       "lint.onAdded": boolean;
       "lint.onGroup": boolean;
       "lint.notify": boolean;
+      "lint.showReportDialog": boolean;
       "lint.numConcurrent": number;
       "lint.delayOnAdded": number;
       "richtext.toolBar": boolean;


### PR DESCRIPTION
## Problem

The report dialog opens unconditionally whenever a lint batch finishes with any records — `Runner.finish()` calls `createReporter()` with no preference gate. Disabling **Show progress notification when Lint** (`lint.notify`) does not affect it, which is surprising: a user who turned notifications off still gets a popup window per batch.

This becomes a real problem during bulk item additions (large imports, or other plugins writing items): with `lint.onAdded` enabled, every batch with warnings spawns another window. In my library this produced a stream of report windows during an import session.

## Change

- New pref `lint.showReportDialog` (**default `true`** — current behavior is preserved exactly; nothing changes for existing users).
- `Runner.finish()` gates `createReporter()` on it.
- Checkbox in the preferences pane, en-US and zh-CN locales included.

Records are still collected and counted in the progress UI's finished line either way; only the popup is optional.

Built and tested locally against Zotero 9.0.6 (`tsc --noEmit` clean, `zotero-plugin build` succeeds, behavior verified with the pref in both states).

Thanks for the plugin — it's the backbone of my library hygiene; this makes it livable during heavy automation.